### PR TITLE
Update log message on use of system default SSLContext

### DIFF
--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
@@ -22,6 +22,9 @@ import java.util.function.Supplier;
 @Slf4j
 public class RegistryAwareClientBuilder implements ClientBuilder {
 
+    private static final String DEFAULT_TLS_INFO_MESSAGE = "No SSLContext provided; if a connection is made" +
+            " via HTTPS, this client will use system default TLS via SSLConnectionSocketFactory.getSocketFactory()";
+
     private final JerseyClientBuilder jerseyClientBuilder = new JerseyClientBuilder();
 
     private boolean sslContextWasSetOnThis;
@@ -109,7 +112,7 @@ public class RegistryAwareClientBuilder implements ClientBuilder {
         setNoopHostNameVerifierIfNotSet();
 
         if (!sslContextWasSetOnThis) {
-            LOG.info("No SSLContext provided; this client will use system default TLS via SSLConnectionSocketFactory.getSocketFactory()");
+            LOG.info(DEFAULT_TLS_INFO_MESSAGE);
         }
 
         return new RegistryAwareClient(jerseyClientBuilder.build(), registryClient, headersSupplier);


### PR DESCRIPTION
Update the INFO log message about using the system default TLS when
connecting to secure endpoints but no explicit SSLContext has been
configured in RegistryAwareClientBuilder.

Fixes #34