### PR TITLE
Add withConnector(PortType) to ServiceIdentifier

### DIFF
--- a/src/test/java/org/kiwiproject/jersey/client/ServiceIdentifierTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/ServiceIdentifierTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.kiwiproject.registry.model.Port;
+import org.kiwiproject.registry.model.Port.PortType;
 import org.kiwiproject.yaml.YamlHelper;
 
 @DisplayName("ServiceIdentifier")
@@ -33,7 +33,7 @@ class ServiceIdentifierTest {
         softly.assertThat(identifier.getServiceName()).isEqualTo("test-service");
         softly.assertThat(identifier.getPreferredVersion()).isNull();
         softly.assertThat(identifier.getMinimumVersion()).isNull();
-        softly.assertThat(identifier.getConnector()).isEqualTo(Port.PortType.APPLICATION);
+        softly.assertThat(identifier.getConnector()).isEqualTo(PortType.APPLICATION);
         softly.assertThat(identifier.getConnectTimeout()).isEqualTo(RegistryAwareClientConstants.DEFAULT_CONNECT_TIMEOUT);
         softly.assertThat(identifier.getReadTimeout()).isEqualTo(RegistryAwareClientConstants.DEFAULT_READ_TIMEOUT);
     }
@@ -44,7 +44,7 @@ class ServiceIdentifierTest {
                 .serviceName("copy-service")
                 .preferredVersion("42.0.0")
                 .minimumVersion("42.0.0")
-                .connector(Port.PortType.ADMIN)
+                .connector(PortType.ADMIN)
                 .connectTimeout(Duration.milliseconds(1))
                 .readTimeout(Duration.milliseconds(5))
                 .build();
@@ -65,7 +65,7 @@ class ServiceIdentifierTest {
                 .serviceName("copy-service")
                 .preferredVersion("42.0.0")
                 .minimumVersion("42.0.0")
-                .connector(Port.PortType.ADMIN)
+                .connector(PortType.ADMIN)
                 .connectTimeout(Duration.milliseconds(1))
                 .readTimeout(Duration.milliseconds(5))
                 .build();
@@ -89,7 +89,7 @@ class ServiceIdentifierTest {
         softly.assertThat(identifier.getServiceName()).isEqualTo("config-test-service");
         softly.assertThat(identifier.getPreferredVersion()).isEqualTo("42.0.1");
         softly.assertThat(identifier.getMinimumVersion()).isEqualTo("42.0.0");
-        softly.assertThat(identifier.getConnector()).isEqualTo(Port.PortType.ADMIN);
+        softly.assertThat(identifier.getConnector()).isEqualTo(PortType.ADMIN);
         softly.assertThat(identifier.getConnectTimeout()).isEqualTo(Duration.milliseconds(5));
         softly.assertThat(identifier.getReadTimeout()).isEqualTo(Duration.milliseconds(10));
     }
@@ -103,7 +103,7 @@ class ServiceIdentifierTest {
                     .serviceName("copy-service")
                     .preferredVersion("42.0.0")
                     .minimumVersion("42.0.0")
-                    .connector(Port.PortType.ADMIN)
+                    .connector(PortType.ADMIN)
                     .connectTimeout(Duration.milliseconds(1))
                     .readTimeout(Duration.milliseconds(5))
                     .build();


### PR DESCRIPTION
* The actual change is just a Lombok "@With" annotation. Since Lombok
  therefore generates this method, added the documentation to the class,
  but because Javadoc doesn't "see" Lombok-generated methods and will
  fail if you use "{@link ...}", instead used "{@code ...}"
* Other misc changes are just to import PortType so we don't have
  Port.PortType all over the place. Did this in ServiceIdentifier and
  ServiceIdentifierTest.
* Did not add any tests, because we're assuming Lombok works correctly

Closes #41