### PR TITLE
Add extra overloads to targetForService

### DIFF
--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
@@ -159,7 +159,7 @@ public class RegistryAwareClient implements Client {
 
     /**
      * Provide a {@link WebTarget} by looking up a service in the registry using the given service identifier.
-     * If more than one instance is found, then one of them is randomly chosen. The given {@link Function} will allow
+     * If more than one instance is found, then one of them is randomly chosen. The given {@code pathResolver} function allows
      * a path to be chosen from the {@link ServiceInstance} and added to the {@link WebTarget} path.
      * <p>
      * Note: By specifying the connector as {@link PortType#ADMIN} in {@code identifier} the {@link WebTarget} will be

--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
@@ -161,9 +161,6 @@ public class RegistryAwareClient implements Client {
      * Provide a {@link WebTarget} by looking up a service in the registry using the given service identifier.
      * If more than one instance is found, then one of them is randomly chosen. The given {@code pathResolver} function allows
      * a path to be chosen from the {@link ServiceInstance} and added to the {@link WebTarget} path.
-     * <p>
-     * Note: By specifying the connector as {@link PortType#ADMIN} in {@code identifier} the {@link WebTarget} will be
-     * set up to access the admin port on the service.
      *
      * @param original      the original {@link ServiceIdentifier} used to lookup a service
      * @param portType      the port type (APPLICATION or ADMIN) to use for the WebTarget port

--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
@@ -171,7 +171,7 @@ public class RegistryAwareClient implements Client {
      * @return a {@link WebTarget} for a randomly selected service instance
      */
     public WebTarget targetForService(ServiceIdentifier original, PortType portType, Function<ServiceInstance, String> pathResolver) {
-        var identifier = original.toBuilder().connector(portType).build();
+        var identifier = original.withConnector(portType);
 
         var instanceQuery = RegistryClient.InstanceQuery.builder()
                 .serviceName(identifier.getServiceName())

--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
@@ -115,7 +115,7 @@ public class RegistryAwareClient implements Client {
 
     /**
      * Provide a {@link WebTarget} by looking up a service in the registry using the given {@link ServiceIdentifier} and
-     * {@link org.kiwiproject.registry.model.Port.PortType}. Finds the latest available version. If more than one
+     * {@link org.kiwiproject.registry.model.Port.PortType PortType}. Finds the latest available version. If more than one
      * instance is found, then one of them is randomly chosen.
      *
      * @param originalIdentifier    the original identifier that will be adjusted with the given port type

--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
@@ -125,9 +125,7 @@ public class RegistryAwareClient implements Client {
      */
     public WebTarget targetForService(ServiceIdentifier originalIdentifier, PortType portType) {
         checkArgumentNotNull(originalIdentifier, "Original ServiceIdentifier must not be null");
-        var serviceIdentifier = originalIdentifier.toBuilder()
-                .connector(portType)
-                .build();
+        var serviceIdentifier = originalIdentifier.withConnector(portType);
 
         return targetForService(serviceIdentifier);
     }

--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientTest.java
@@ -195,6 +195,41 @@ class RegistryAwareClientTest {
                 assertThat(target.getUri()).hasToString(expectedUri);
             }
         }
+
+        @Nested
+        class WithServiceIdentifierAndPortType {
+
+            @ParameterizedTest
+            @CsvSource({
+                    "APPLICATION, https://localhost:8080/home",
+                    "ADMIN, https://localhost:8081/"
+            })
+            void shouldBuildClientForSpecifiedPortType(PortType portType, String expectedUri) {
+                when(registryClient.findServiceInstanceBy(any(RegistryClient.InstanceQuery.class)))
+                        .thenReturn(Optional.of(instance));
+
+                var identifier = ServiceIdentifier.builder().serviceName("test-service").build();
+                var target = registryAwareClient.targetForService(identifier, portType);
+
+                assertThat(target.getUri()).hasToString(expectedUri);
+            }
+        }
+
+        @Nested
+        class WithServiceIdentifierAndPortTypeAndPathResolver {
+
+            @Test
+            void shouldBuildClientForWith() {
+                when(registryClient.findServiceInstanceBy(any(RegistryClient.InstanceQuery.class)))
+                        .thenReturn(Optional.of(instance));
+
+                var identifier = ServiceIdentifier.builder().serviceName("test-service").build();
+                var target = registryAwareClient.targetForService(identifier, PortType.ADMIN,
+                        instance -> instance.getPaths().getStatusPath());
+
+                assertThat(target.getUri()).hasToString("https://localhost:8081/ping");
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
* targetForService(ServiceIdentifier, PortType) that uses toBuilder to reset the connector
* targetForService(ServiceIdentifier, PortType, Function<ServiceInstance, String>) that adds a path to the target based on the serviceInstance function

Closes #44