### PR TITLE
Add DropwizardClients utility class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,6 @@
       <groupId>org.kiwiproject</groupId>
       <artifactId>service-discovery-client</artifactId>
       <version>${service-discovery-client.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.kiwiproject</groupId>
-          <artifactId>kiwi</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- Provided dependencies -->
@@ -143,6 +137,23 @@
         <exclusion>
           <groupId>com.fasterxml</groupId>
           <artifactId>classmate</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>${jackson.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -244,23 +255,6 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson.version}</version>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>${jackson.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>jakarta.activation</groupId>
-          <artifactId>jakarta.activation-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>jakarta.xml.bind</groupId>
-          <artifactId>jakarta.xml.bind-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
   </dependencies>

--- a/src/main/java/org/kiwiproject/jersey/client/dropwizard/DropwizardClients.java
+++ b/src/main/java/org/kiwiproject/jersey/client/dropwizard/DropwizardClients.java
@@ -1,0 +1,48 @@
+package org.kiwiproject.jersey.client.dropwizard;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import lombok.experimental.UtilityClass;
+
+import javax.ws.rs.client.Client;
+
+/**
+ * Utilities for adding Dropwizard features to JAX-RS Clients.
+ */
+@UtilityClass
+public class DropwizardClients {
+
+    /**
+     * Adds a {@link JacksonMessageBodyProvider} to the given {@link Client}.
+     * <p>
+     * See the note explaining when this is not needed in the description of
+     * {@link #addJacksonMessageBodyProvider(Client, JacksonMessageBodyProvider)}.
+     *
+     * @param client the Client to add the {@link JacksonMessageBodyProvider}
+     * @param mapper the {@link ObjectMapper} that will be supplied to the {@link JacksonMessageBodyProvider}
+     * @return the Client argument, for method chaining
+     * @see #addJacksonMessageBodyProvider(Client, JacksonMessageBodyProvider)
+     */
+    public static Client addJacksonMessageBodyProvider(Client client, ObjectMapper mapper) {
+        return addJacksonMessageBodyProvider(client, new JacksonMessageBodyProvider(mapper));
+    }
+
+    /**
+     * Adds the {@link JacksonMessageBodyProvider} to the given {@link Client}.
+     * <p>
+     * Note that this is not necessary when using {@link DropwizardManagedClientBuilder} to build clients, because
+     * Dropwizard adds {@link JacksonMessageBodyProvider}. It is mainly useful in a Dropwizard application when using
+     * {@link org.kiwiproject.jersey.client.RegistryAwareClientBuilder RegistryAwareClientBuilder} to build clients,
+     * since it is not aware of Dropwizard, and you need to customize JSON serialization via a custom
+     * {@link ObjectMapper}. For example, if you use milliseconds for all timestamps instead of Jackson's default
+     * serialization of Java date/time objects like {@link java.time.ZonedDateTime}, you need to configure the
+     * ObjectMapper to read and write timestamps as milliseconds.
+     *
+     * @param client   the Client to add the {@link JacksonMessageBodyProvider}
+     * @param provider the {@link JacksonMessageBodyProvider} to add
+     * @return the Client argument, for method chaining
+     */
+    public static Client addJacksonMessageBodyProvider(Client client, JacksonMessageBodyProvider provider) {
+        return client.register(provider);
+    }
+}

--- a/src/test/java/org/kiwiproject/jersey/client/dropwizard/DropwizardClientsTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/dropwizard/DropwizardClientsTest.java
@@ -1,0 +1,175 @@
+package org.kiwiproject.jersey.client.dropwizard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.kiwiproject.test.constants.KiwiTestConstants.JSON_HELPER;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.testing.junit5.DropwizardClientExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import lombok.Builder;
+import lombok.Value;
+import lombok.With;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.jersey.client.ClientBuilders;
+import org.kiwiproject.jersey.client.RegistryAwareClient;
+import org.kiwiproject.json.JsonHelper;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.concurrent.ThreadLocalRandom;
+
+@DisplayName("DropwizardClients")
+@ExtendWith(DropwizardExtensionsSupport.class)
+@Slf4j
+class DropwizardClientsTest {
+
+    @Path("/dropwizardClients")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Slf4j
+    public static class TestResource {
+
+        public TestResource() {
+            LOG.info("TestResource: constructor");
+        }
+
+        @GET
+        @Path("/{id}")
+        public Response get(@PathParam("id") Long id) {
+            var alice = newSamplePerson(id);
+
+            return Response.ok(alice).build();
+        }
+
+        @POST
+        public Response create(@NotNull Person person) {
+            Long id = Math.abs(ThreadLocalRandom.current().nextLong(1_000));
+            var createdPerson = person.withId(id);
+            var location = UriBuilder.fromResource(TestResource.class)
+                    .path("/{id}")
+                    .resolveTemplate("id", id)
+                    .build();
+            return Response.created(location).entity(createdPerson).build();
+        }
+
+        @PUT
+        public Response update(@NotNull Person person) {
+            var updatedPerson = person.withUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+            return Response.ok(updatedPerson).build();
+        }
+    }
+
+    @Value
+    @Builder
+    private static class Person {
+
+        @With
+        Long id;
+        String firstName;
+        String lastName;
+        String email;
+        int age;
+        ZonedDateTime createdAt;
+        @With
+        ZonedDateTime updatedAt;
+    }
+
+    private static final DropwizardClientExtension CLIENT_EXTENSION = new DropwizardClientExtension(new TestResource());
+
+    private static String baseUri;
+
+    @BeforeAll
+    static void beforeAll() {
+        baseUri = CLIENT_EXTENSION.baseUri().toString();
+
+        // IMPORTANT: configure so ZonedDateTime are serialized as millis
+        JsonHelper.configureForMillisecondDateTimestamps(CLIENT_EXTENSION.getObjectMapper());
+    }
+
+    @Nested
+    class AddJacksonMessageBodyProvider {
+
+        @Test
+        void shouldReturnSameDelegateClientInstance() {
+            var mapper = new ObjectMapper();
+            RegistryAwareClient originalClient = ClientBuilders.jersey().build();
+            Client client = DropwizardClients.addJacksonMessageBodyProvider(originalClient, mapper);
+
+            assertThat(client)
+                    .describedAs("The returned Client should be the same as the Client @Delegate in RegistryAwareClient")
+                    .isSameAs(originalClient.client());
+        }
+
+        @Test
+        void shouldDeserializeJsonResponses() {
+            var registryAwareClient = ClientBuilders.jersey().build();
+            DropwizardClients.addJacksonMessageBodyProvider(registryAwareClient, CLIENT_EXTENSION.getObjectMapper());
+
+            var id = 42L;
+            var response = registryAwareClient.target(baseUri)
+                    .path("/dropwizardClients/{id}")
+                    .resolveTemplate("id", id)
+                    .request()
+                    .get();
+
+            var entity = response.readEntity(Person.class);
+            var expectedSamplePerson = newSamplePerson(id);
+            assertThat(entity).isEqualTo(expectedSamplePerson);
+        }
+
+        @Test
+        void shouldUseCustomizedObjectMapperToWriteTimestampsAsMillis() {
+            var registryAwareClient = ClientBuilders.jersey().build();
+            DropwizardClients.addJacksonMessageBodyProvider(registryAwareClient, CLIENT_EXTENSION.getObjectMapper());
+
+            var id = 42L;
+            var response = registryAwareClient.target(baseUri)
+                    .path("/dropwizardClients/{id}")
+                    .resolveTemplate("id", id)
+                    .request()
+                    .get();
+
+            var json = response.readEntity(String.class);
+            var entity = JSON_HELPER.toMap(json);
+
+            var samplePerson = newSamplePerson(id);
+            assertThat(entity)
+                    .describedAs("JSON should contain epoch millis from customized MObjectMapper")
+                    .contains(
+                            entry("createdAt", samplePerson.getCreatedAt().toInstant().toEpochMilli()),
+                            entry("updatedAt", samplePerson.getUpdatedAt().toInstant().toEpochMilli())
+                    );
+        }
+    }
+
+    private static Person newSamplePerson(Long id) {
+        return Person.builder()
+                .id(id)
+                .firstName("Alice")
+                .lastName("Smith")
+                .email("alice.smith@gmail.com")
+                .age(42)
+                .createdAt(ZonedDateTime.of(2020, 3, 31, 12, 0, 0, 0, ZoneId.of("UTC")))
+                .updatedAt(ZonedDateTime.of(2020, 11, 15, 14, 30, 0, 0, ZoneId.of("UTC")))
+                .build();
+    }
+}


### PR DESCRIPTION
* Add DropwizardClients, which provides the ability to register a
  Dropwizard JacksonMessageBodyProvider on a JAX-RS Client
* Because DropwizardClients uses JacksonMessageBodyProvider, which in
  turn extends the Jackson class JacksonJaxbJsonProvider, had to change
  the jackson-jaxrs-json-provider scope from test to provided
* Was able to remove kiwi exclusion from service-discovery-client
  since there are no more convergence errors

Closes #50