### PR TITLE
Log warning if TlsConfigProvider cannot provide

### DIFF
--- a/src/main/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilder.java
@@ -173,8 +173,15 @@ public class DropwizardManagedClientBuilder {
         config.setConnectionTimeout(RegistryAwareClientConstants.DEFAULT_CONNECT_TIMEOUT);
         config.setTimeout(RegistryAwareClientConstants.DEFAULT_READ_TIMEOUT);
 
-        if (nonNull(tlsConfigProvider) && tlsConfigProvider.canProvide()) {
+        if (isNull(tlsConfigProvider)) {
+            return config;
+        }
+
+        if (tlsConfigProvider.canProvide()) {
             config.setTlsConfiguration(tlsConfigProvider.getTlsContextConfiguration().toDropwizardTlsConfiguration());
+        } else {
+            LOG.warn("TlsConfigProvider.canProvide() returned false; " +
+                    "custom TlsConfiguration cannot be set for default JerseyClientConfiguration");
         }
 
         return config;


### PR DESCRIPTION
If TlsConfigProvider is supplied but cannot provide, log a warning.

Closes #54