### PR TITLE
Add ability to set timeouts from ServiceIdentifier in ClientBuilder

### DIFF
--- a/src/main/java/org/kiwiproject/jersey/client/ClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/ClientBuilder.java
@@ -12,19 +12,19 @@ import java.util.function.Supplier;
  * Configure and create {@link RegistryAwareClient} instances using a fluent builder interface. Use {@link ClientBuilders}
  * to get a builder instance.
  * <p>
- * Inspired by {@link javax.ws.rs.client.ClientBuilder}
+ * Inspired by {@link javax.ws.rs.client.ClientBuilder}.
  */
 public interface ClientBuilder {
 
     /**
-     * Enables the multipart feature on the client
+     * Enables the multipart feature on the client.
      *
      * @return this builder
      */
     ClientBuilder multipart();
 
     /**
-     * Sets the connect timeout for the client
+     * Sets the connect timeout for the client.
      *
      * @param millis length of timeout in millis
      * @return this builder
@@ -32,7 +32,7 @@ public interface ClientBuilder {
     ClientBuilder connectTimeout(int millis);
 
     /**
-     * Sets the connect timeout for the client
+     * Sets the connect timeout for the client.
      *
      * @param millis length of timeout in millis
      * @return this builder
@@ -40,7 +40,7 @@ public interface ClientBuilder {
     ClientBuilder connectTimeout(long millis);
 
     /**
-     * Sets the read timeout for the client
+     * Sets the read timeout for the client.
      *
      * @param millis length of timeout in millis
      * @return this builder
@@ -48,7 +48,7 @@ public interface ClientBuilder {
     ClientBuilder readTimeout(int millis);
 
     /**
-     * Sets the read timeout for the client
+     * Sets the read timeout for the client.
      *
      * @param millis length of timeout in millis
      * @return this builder
@@ -56,7 +56,22 @@ public interface ClientBuilder {
     ClientBuilder readTimeout(long millis);
 
     /**
-     * Sets the hostname verifier for the client
+     * Sets the connect and read timeouts for the client from a {@link ServiceIdentifier}. This is most useful
+     * when you already have a {@link ServiceIdentifier} for a specific service, and you want to create a new
+     * {@link RegistryAwareClient} for use making requests to that service. This in no way precludes using the
+     * client to connect to any other service, but is a convenience when you are using the "bulkhead" pattern.
+     * <p>
+     * See Michael Nygard's excellent book <a href="https://pragprog.com/titles/mnee2/release-it-second-edition/">Release It!</a>
+     * for information on stability patterns including bulkheads. Microsoft also has a good description in their
+     * <a href="https://docs.microsoft.com/en-us/azure/architecture/patterns/bulkhead">Azure design patterns</a>.
+     *
+     * @param serviceIdentifier defines the read and connect timeouts to set on the client
+     * @return this builder
+     */
+    ClientBuilder timeoutsFrom(ServiceIdentifier serviceIdentifier);
+
+    /**
+     * Sets the hostname verifier for the client.
      *
      * @param hostnameVerifier The {@link HostnameVerifier} to use
      * @return this builder
@@ -64,7 +79,7 @@ public interface ClientBuilder {
     ClientBuilder hostnameVerifier(HostnameVerifier hostnameVerifier);
 
     /**
-     * Sets the SSL context for the client
+     * Sets the SSL context for the client.
      *
      * @param sslContext The {@link SSLContext} to use
      * @return this builder
@@ -72,7 +87,7 @@ public interface ClientBuilder {
     ClientBuilder sslContext(SSLContext sslContext);
 
     /**
-     * Provides a {@link TlsConfigProvider} to use to provide TLS configuration
+     * Provides a {@link TlsConfigProvider} to use to provide TLS configuration.
      *
      * @param tlsConfigProvider The config provider to provide TLS settings
      * @return this builder
@@ -80,7 +95,7 @@ public interface ClientBuilder {
     ClientBuilder tlsConfigProvider(TlsConfigProvider tlsConfigProvider);
 
     /**
-     * Provides the {@link RegistryClient} to use to find services
+     * Provides the {@link RegistryClient} to use to find services.
      *
      * @param registryClient The {@link RegistryClient} responsible for looking up services to connect to
      * @return this builder
@@ -97,7 +112,7 @@ public interface ClientBuilder {
     ClientBuilder headersSupplier(Supplier<Map<String, Object>> headersSupplier);
 
     /**
-     * Builds the {@link RegistryAwareClient} with the configured options
+     * Builds the {@link RegistryAwareClient} with the configured options.
      *
      * @return a {@link RegistryAwareClient}
      */

--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
@@ -61,6 +61,13 @@ public class RegistryAwareClientBuilder implements ClientBuilder {
     }
 
     @Override
+    public ClientBuilder timeoutsFrom(ServiceIdentifier serviceIdentifier) {
+        connectTimeout(serviceIdentifier.getConnectTimeout().toMilliseconds());
+        readTimeout(serviceIdentifier.getReadTimeout().toMilliseconds());
+        return this;
+    }
+
+    @Override
     public ClientBuilder hostnameVerifier(HostnameVerifier hostnameVerifier) {
         jerseyClientBuilder.hostnameVerifier(hostnameVerifier);
         hostnameVerifierWasSetOnThis = true;

--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.mock;
 
+import io.dropwizard.util.Duration;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -65,6 +66,26 @@ class RegistryAwareClientBuilderTest {
                 .contains(
                         entry(ClientProperties.CONNECT_TIMEOUT, 1_000),
                         entry(ClientProperties.READ_TIMEOUT, 2_000)
+                );
+    }
+
+    @Test
+    void shouldSetTimeoutsFromServiceIdentifier() {
+        var serviceId = ServiceIdentifier.builder()
+                .serviceName("test-service")
+                .connectTimeout(Duration.seconds(2))
+                .readTimeout(Duration.seconds(3))
+                .build();
+
+        client = builder
+                .timeoutsFrom(serviceId)
+                .hostnameVerifier(new NoopHostnameVerifier())
+                .build();
+
+        assertThat(client.getConfiguration().getProperties())
+                .contains(
+                        entry(ClientProperties.CONNECT_TIMEOUT, 2_000),
+                        entry(ClientProperties.READ_TIMEOUT, 3_000)
                 );
     }
 


### PR DESCRIPTION
* Add timeoutsFrom(ServiceIdentifier) to ClientBuilder
* Implement timeoutsFrom in RegistryAwareClientBuilder

Closes #56