### PR TITLE
Improve log message if exception converting TlsContextConfiguration

### DIFF
--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
@@ -91,7 +91,8 @@ public class RegistryAwareClientBuilder implements ClientBuilder {
         try {
             return sslContext(tlsContextConfig.toSSLContext());
         } catch (Exception e) {
-            LOG.warn("Unable to convert TlsContextConfiguration to SSLContext");
+            LOG.warn("Unable to convert TlsContextConfiguration to SSLContext: {}: {}",
+                    e.getClass().getName(), e.getMessage());
             LOG.debug("TlsContextConfiguration conversion exception: ", e);
         }
 

--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.glassfish.jersey.client.ClientProperties;
@@ -19,6 +21,8 @@ import org.kiwiproject.config.provider.FieldResolverStrategy;
 import org.kiwiproject.config.provider.TlsConfigProvider;
 import org.kiwiproject.jersey.client.RegistryAwareClient.AddHeadersOnRequestFilter;
 import org.kiwiproject.registry.client.RegistryClient;
+import org.kiwiproject.security.SSLContextException;
+import org.kiwiproject.test.junit.jupiter.WhiteBoxTest;
 import org.kiwiproject.test.util.Fixtures;
 
 import javax.net.ssl.HostnameVerifier;
@@ -141,6 +145,24 @@ class RegistryAwareClientBuilderTest {
         client = builder.tlsConfigProvider(provider).build();
 
         assertThat(client.getSslContext()).isNotNull();
+    }
+
+    @WhiteBoxTest
+    void shouldNotThrowException_WhenTlsConfigProvider_ThrowsExceptionConvertingToSSLContext() {
+        var tlsConfig = mock(TlsContextConfiguration.class);
+        when(tlsConfig.toSSLContext()).thenThrow(new SSLContextException("Error creating SSLContext"));
+
+        var tlsConfigProvider = mock(TlsConfigProvider.class);
+        when(tlsConfigProvider.canProvide()).thenReturn(true);
+        when(tlsConfigProvider.getTlsContextConfiguration()).thenReturn(tlsConfig);
+
+        assertThatCode(() -> builder.tlsConfigProvider(tlsConfigProvider).build()).doesNotThrowAnyException();
+        verify(tlsConfig).toSSLContext();
+
+        var client = builder.tlsConfigProvider(tlsConfigProvider).build();
+        assertThat(client.getSslContext())
+                .describedAs("Should still have a non-null, default SSLContext")
+                .isNotNull();
     }
 
     private static String getUnitTestKeyStorePath() {


### PR DESCRIPTION
* Improve log message in RegistryAwareClientBuilder#tlsConfigProvider
  if an exception is caught converting the TlsContextConfiguration to
  an SSLContext by including the exception class and message.
* Add test (alas, with mocks) to verify no exception is thrown by
  RegistryAwareClientBuilder#tlsConfigProvider even if an exception
  occurs converting the TlsContextConfiguration to an SSLContext