### PR TITLE
Add headerSupplier to DropwizardManagedClientBuilder

### DIFF
--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
@@ -194,6 +194,7 @@ public class RegistryAwareClient implements Client {
         return ServiceInstancePaths.urlForPath(instance.getHostName(), instance.getPorts(), identifier.getConnector(), path);
     }
 
+    @VisibleForTesting
     static class AddHeadersOnRequestFilter implements ClientRequestFilter {
 
         private final Supplier<Map<String, Object>> headersSupplier;

--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.kiwiproject.jersey.client.util.JerseyTestHelpers.isFeatureRegistered;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,7 +23,6 @@ import org.kiwiproject.config.TlsContextConfiguration;
 import org.kiwiproject.config.provider.FieldResolverStrategy;
 import org.kiwiproject.config.provider.TlsConfigProvider;
 import org.kiwiproject.jersey.client.RegistryAwareClient.AddHeadersOnRequestFilter;
-import org.kiwiproject.jersey.client.util.JerseyTestHelpers;
 import org.kiwiproject.registry.NoOpRegistryClient;
 import org.kiwiproject.registry.client.RegistryClient;
 import org.kiwiproject.security.SSLContextException;
@@ -219,14 +219,14 @@ class RegistryAwareClientBuilderTest {
     void shouldRegisterMultipartFeatureWhenRequested() {
         client = builder.registryClient(registryClient).multipart().build();
 
-        assertThat(JerseyTestHelpers.isFeatureRegistered(client, MultiPartFeature.class)).isTrue();
+        assertThat(isFeatureRegistered(client, MultiPartFeature.class)).isTrue();
     }
 
     @Test
     void shouldNotRegisterHeadersSupplierWhenNull() {
         client = builder.registryClient(registryClient).build();
 
-        assertThat(JerseyTestHelpers.isFeatureRegistered(client, AddHeadersOnRequestFilter.class)).isFalse();
+        assertThat(isFeatureRegistered(client, AddHeadersOnRequestFilter.class)).isFalse();
     }
 
     @Test
@@ -236,7 +236,7 @@ class RegistryAwareClientBuilderTest {
                 .headersSupplier(() -> Map.of("X-Custom-Value", "Foo-42"))
                 .build();
 
-        assertThat(JerseyTestHelpers.isFeatureRegistered(client, AddHeadersOnRequestFilter.class)).isTrue();
+        assertThat(isFeatureRegistered(client, AddHeadersOnRequestFilter.class)).isTrue();
     }
 
 }

--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
@@ -22,6 +22,7 @@ import org.kiwiproject.config.TlsContextConfiguration;
 import org.kiwiproject.config.provider.FieldResolverStrategy;
 import org.kiwiproject.config.provider.TlsConfigProvider;
 import org.kiwiproject.jersey.client.RegistryAwareClient.AddHeadersOnRequestFilter;
+import org.kiwiproject.jersey.client.util.JerseyTestHelpers;
 import org.kiwiproject.registry.NoOpRegistryClient;
 import org.kiwiproject.registry.client.RegistryClient;
 import org.kiwiproject.security.SSLContextException;
@@ -218,14 +219,14 @@ class RegistryAwareClientBuilderTest {
     void shouldRegisterMultipartFeatureWhenRequested() {
         client = builder.registryClient(registryClient).multipart().build();
 
-        assertThat(isFeatureRegistered(client, MultiPartFeature.class)).isTrue();
+        assertThat(JerseyTestHelpers.isFeatureRegistered(client, MultiPartFeature.class)).isTrue();
     }
 
     @Test
     void shouldNotRegisterHeadersSupplierWhenNull() {
         client = builder.registryClient(registryClient).build();
 
-        assertThat(isFeatureRegistered(client, AddHeadersOnRequestFilter.class)).isFalse();
+        assertThat(JerseyTestHelpers.isFeatureRegistered(client, AddHeadersOnRequestFilter.class)).isFalse();
     }
 
     @Test
@@ -235,10 +236,7 @@ class RegistryAwareClientBuilderTest {
                 .headersSupplier(() -> Map.of("X-Custom-Value", "Foo-42"))
                 .build();
 
-        assertThat(isFeatureRegistered(client, AddHeadersOnRequestFilter.class)).isTrue();
+        assertThat(JerseyTestHelpers.isFeatureRegistered(client, AddHeadersOnRequestFilter.class)).isTrue();
     }
 
-    private static boolean isFeatureRegistered(RegistryAwareClient client, Class<?> component) {
-        return client.getConfiguration().isRegistered(component);
-    }
 }

--- a/src/test/java/org/kiwiproject/jersey/client/util/JerseyTestHelpers.java
+++ b/src/test/java/org/kiwiproject/jersey/client/util/JerseyTestHelpers.java
@@ -1,0 +1,13 @@
+package org.kiwiproject.jersey.client.util;
+
+import lombok.experimental.UtilityClass;
+
+import javax.ws.rs.client.Client;
+
+@UtilityClass
+public class JerseyTestHelpers {
+
+    public static boolean isFeatureRegistered(Client client, Class<?> component) {
+        return client.getConfiguration().isRegistered(component);
+    }
+}


### PR DESCRIPTION
* Add headerSupplier to DropwizardManagedClientBuilder
* Annotate RegistryAwareClient.AddHeadersOnRequestFilter with
  VisibleForTesting to make clear why it is package-private
* Extract isFeatureRegistered test utility into JerseyTestHelpers so it
  can be used by both client tests

Closes #90