### PR TITLE
Remove kiwi-test exclusion from dropwizard-config-providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,13 +67,6 @@
             <groupId>org.kiwiproject</groupId>
             <artifactId>dropwizard-config-providers</artifactId>
             <version>${dropwizard-config-providers.version}</version>
-            <exclusions>
-                <!-- TODO REMOVE THIS ONCE UPDATE TO dropwizard-config-providers 1.1.0 -->
-                <exclusion>
-                    <groupId>org.kiwiproject</groupId>
-                    <artifactId>kiwi-test</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
We can now remove the kiwi-test exclusion since we updated
dropwizard-config-providers to 1.1.0, which fixed it by making kiwi-test
have 'test' scope in the POM instead of compile.