### PR TITLE
Sonar cleanup: RegistryAwareClientBuilderTest

### DIFF
--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
@@ -196,7 +196,7 @@ class RegistryAwareClientBuilderTest {
                 .doesNotThrowAnyException();
         verify(tlsConfig).toSSLContext();
 
-        var client = builder.tlsConfigProvider(tlsConfigProvider).build();
+        client = builder.tlsConfigProvider(tlsConfigProvider).build();
         assertThat(client.getSslContext())
                 .describedAs("Should still have a non-null, default SSLContext")
                 .isNotNull();
@@ -208,7 +208,7 @@ class RegistryAwareClientBuilderTest {
 
     @Test
     void shouldAcceptGivenRegistryClient() {
-        var registryClient = mock(RegistryClient.class);
+        registryClient = mock(RegistryClient.class);
 
         client = builder.registryClient(registryClient).build();
 


### PR DESCRIPTION
Don't hide instance fields. Instead, re-assign them in the tests.