### PR TITLE
Sonar cleanup: RegistryAwareClientTest

### DIFF
--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientTest.java
@@ -238,7 +238,7 @@ class RegistryAwareClientTest {
 
                 var identifier = ServiceIdentifier.builder().serviceName("test-service").build();
                 var target = registryAwareClient.targetForService(identifier, PortType.ADMIN,
-                        instance -> instance.getPaths().getStatusPath());
+                        theInstance -> theInstance.getPaths().getStatusPath());
 
                 assertThat(target.getUri()).hasToString("https://localhost:8081/ping");
             }


### PR DESCRIPTION
Change lambda parameter so it doesn't shadow an instance field.