### PR TITLE
Fix capitalization of config properties in lombok.config

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,3 +1,3 @@
-lombok.log.fieldname=LOG
-lombok.anyconstructor.addconstructorproperties=true
+lombok.log.fieldName=LOG
+lombok.anyConstructor.addConstructorProperties=true
 lombok.addLombokGeneratedAnnotation=true


### PR DESCRIPTION
Lombok still works, but we should use the proper capitalization.