### PR TITLE
Move AddHeadersOnRequestFilter client header filter to top-level

### DIFF
--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
@@ -215,20 +215,4 @@ public class RegistryAwareClient implements Client, AutoCloseable {
         return ServiceInstancePaths.urlForPath(instance.getHostName(), instance.getPorts(), identifier.getConnector(), path);
     }
 
-//    @VisibleForTesting
-//    static class AddHeadersOnRequestFilter implements ClientRequestFilter {
-//
-//        private final Supplier<Map<String, Object>> headersSupplier;
-//
-//        AddHeadersOnRequestFilter(Supplier<Map<String, Object>> headersSupplier) {
-//            this.headersSupplier = headersSupplier;
-//        }
-//
-//        @Override
-//        public void filter(ClientRequestContext requestContext) {
-//            var headers = headersSupplier.get();
-//            headers.forEach((key, value) -> requestContext.getHeaders().add(key, value));
-//        }
-//    }
-
 }

--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClient.java
@@ -6,8 +6,6 @@ import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientRequestContext;
-import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.client.WebTarget;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,6 +13,7 @@ import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.kiwiproject.jersey.client.exception.MissingServiceRuntimeException;
+import org.kiwiproject.jersey.client.filter.AddHeadersClientRequestFilter;
 import org.kiwiproject.registry.client.RegistryClient;
 import org.kiwiproject.registry.model.Port.PortType;
 import org.kiwiproject.registry.model.ServiceInstance;
@@ -70,7 +69,7 @@ public class RegistryAwareClient implements Client, AutoCloseable {
         this.closed = new AtomicBoolean();
 
         if (nonNull(headersSupplier)) {
-            this.client.register(new AddHeadersOnRequestFilter(headersSupplier));
+            this.client.register(new AddHeadersClientRequestFilter(headersSupplier));
         }
     }
 
@@ -216,20 +215,20 @@ public class RegistryAwareClient implements Client, AutoCloseable {
         return ServiceInstancePaths.urlForPath(instance.getHostName(), instance.getPorts(), identifier.getConnector(), path);
     }
 
-    @VisibleForTesting
-    static class AddHeadersOnRequestFilter implements ClientRequestFilter {
-
-        private final Supplier<Map<String, Object>> headersSupplier;
-
-        AddHeadersOnRequestFilter(Supplier<Map<String, Object>> headersSupplier) {
-            this.headersSupplier = headersSupplier;
-        }
-
-        @Override
-        public void filter(ClientRequestContext requestContext) {
-            var headers = headersSupplier.get();
-            headers.forEach((key, value) -> requestContext.getHeaders().add(key, value));
-        }
-    }
+//    @VisibleForTesting
+//    static class AddHeadersOnRequestFilter implements ClientRequestFilter {
+//
+//        private final Supplier<Map<String, Object>> headersSupplier;
+//
+//        AddHeadersOnRequestFilter(Supplier<Map<String, Object>> headersSupplier) {
+//            this.headersSupplier = headersSupplier;
+//        }
+//
+//        @Override
+//        public void filter(ClientRequestContext requestContext) {
+//            var headers = headersSupplier.get();
+//            headers.forEach((key, value) -> requestContext.getHeaders().add(key, value));
+//        }
+//    }
 
 }

--- a/src/main/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilder.java
@@ -6,19 +6,17 @@ import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.core.setup.Environment;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientRequestContext;
-import jakarta.ws.rs.client.ClientRequestFilter;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.kiwiproject.config.TlsContextConfiguration;
 import org.kiwiproject.config.provider.TlsConfigProvider;
 import org.kiwiproject.jersey.client.RegistryAwareClient;
 import org.kiwiproject.jersey.client.RegistryAwareClientConstants;
+import org.kiwiproject.jersey.client.filter.AddHeadersClientRequestFilter;
 import org.kiwiproject.registry.client.RegistryClient;
 
 import java.util.ArrayList;
@@ -217,7 +215,7 @@ public class DropwizardManagedClientBuilder {
         var client = builder.build(clientName);
 
         if (nonNull(headersSupplier)) {
-            client.register(new AddHeadersOnRequestFilter(headersSupplier));
+            client.register(new AddHeadersClientRequestFilter(headersSupplier));
         }
 
         return client;
@@ -226,21 +224,21 @@ public class DropwizardManagedClientBuilder {
     // TODO Duplicates same class in RegistryAwareClient. If extracted, would need to loosen visibility (make public)!
     //  Consider making a public part of API in new package, e.g. jersey.client.filter.AddHeadersClientRequestFilter.
 
-    @VisibleForTesting
-    static class AddHeadersOnRequestFilter implements ClientRequestFilter {
-
-        private final Supplier<Map<String, Object>> headersSupplier;
-
-        AddHeadersOnRequestFilter(Supplier<Map<String, Object>> headersSupplier) {
-            this.headersSupplier = headersSupplier;
-        }
-
-        @Override
-        public void filter(ClientRequestContext requestContext) {
-            var headers = headersSupplier.get();
-            headers.forEach((key, value) -> requestContext.getHeaders().add(key, value));
-        }
-    }
+//    @VisibleForTesting
+//    static class AddHeadersClientRequestFilter implements ClientRequestFilter {
+//
+//        private final Supplier<Map<String, Object>> headersSupplier;
+//
+//        AddHeadersClientRequestFilter(Supplier<Map<String, Object>> headersSupplier) {
+//            this.headersSupplier = headersSupplier;
+//        }
+//
+//        @Override
+//        public void filter(ClientRequestContext requestContext) {
+//            var headers = headersSupplier.get();
+//            headers.forEach((key, value) -> requestContext.getHeaders().add(key, value));
+//        }
+//    }
 
     /**
      * Create a new Dropwizard-managed {@link RegistryAwareClient} with the same behavior as

--- a/src/main/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilder.java
@@ -221,25 +221,6 @@ public class DropwizardManagedClientBuilder {
         return client;
     }
 
-    // TODO Duplicates same class in RegistryAwareClient. If extracted, would need to loosen visibility (make public)!
-    //  Consider making a public part of API in new package, e.g. jersey.client.filter.AddHeadersClientRequestFilter.
-
-//    @VisibleForTesting
-//    static class AddHeadersClientRequestFilter implements ClientRequestFilter {
-//
-//        private final Supplier<Map<String, Object>> headersSupplier;
-//
-//        AddHeadersClientRequestFilter(Supplier<Map<String, Object>> headersSupplier) {
-//            this.headersSupplier = headersSupplier;
-//        }
-//
-//        @Override
-//        public void filter(ClientRequestContext requestContext) {
-//            var headers = headersSupplier.get();
-//            headers.forEach((key, value) -> requestContext.getHeaders().add(key, value));
-//        }
-//    }
-
     /**
      * Create a new Dropwizard-managed {@link RegistryAwareClient} with the same behavior as
      * {@link #buildManagedJerseyClient()} but also being registry-aware.

--- a/src/main/java/org/kiwiproject/jersey/client/filter/AddHeadersClientRequestFilter.java
+++ b/src/main/java/org/kiwiproject/jersey/client/filter/AddHeadersClientRequestFilter.java
@@ -1,0 +1,31 @@
+package org.kiwiproject.jersey.client.filter;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import com.google.common.annotations.Beta;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * A Jakarta-RS {@link ClientRequestFilter} that adds headers to a request
+ * from a {@link Supplier}.
+*/
+@Beta
+public class AddHeadersClientRequestFilter implements ClientRequestFilter {
+
+    private final Supplier<Map<String, Object>> headersSupplier;
+
+    public AddHeadersClientRequestFilter(Supplier<Map<String, Object>> headersSupplier) {
+        this.headersSupplier = requireNotNull(headersSupplier, "headersSupplier must not be null");
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        var headers = headersSupplier.get();
+        // TODO handle badly behaved Supplier? i.e., that provides us a null value
+        headers.forEach((key, value) -> requestContext.getHeaders().add(key, value));
+    }
+}

--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.kiwiproject.config.TlsContextConfiguration;
 import org.kiwiproject.config.provider.FieldResolverStrategy;
 import org.kiwiproject.config.provider.TlsConfigProvider;
-import org.kiwiproject.jersey.client.RegistryAwareClient.AddHeadersOnRequestFilter;
+import org.kiwiproject.jersey.client.filter.AddHeadersClientRequestFilter;
 import org.kiwiproject.registry.NoOpRegistryClient;
 import org.kiwiproject.registry.client.RegistryClient;
 import org.kiwiproject.security.SSLContextException;
@@ -295,7 +295,7 @@ class RegistryAwareClientBuilderTest {
     void shouldNotRegisterHeadersSupplierWhenNull() {
         client = builder.registryClient(registryClient).build();
 
-        assertThat(isFeatureRegisteredByClass(client, AddHeadersOnRequestFilter.class)).isFalse();
+        assertThat(isFeatureRegisteredByClass(client, AddHeadersClientRequestFilter.class)).isFalse();
     }
 
     @Test
@@ -305,7 +305,7 @@ class RegistryAwareClientBuilderTest {
                 .headersSupplier(() -> Map.of("X-Custom-Value", "Foo-42"))
                 .build();
 
-        assertThat(isFeatureRegisteredByClass(client, AddHeadersOnRequestFilter.class)).isTrue();
+        assertThat(isFeatureRegisteredByClass(client, AddHeadersClientRequestFilter.class)).isTrue();
     }
 
 }

--- a/src/test/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilderTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilderTest.java
@@ -37,7 +37,7 @@ import org.kiwiproject.config.provider.FieldResolverStrategy;
 import org.kiwiproject.config.provider.TlsConfigProvider;
 import org.kiwiproject.jersey.client.RegistryAwareClient;
 import org.kiwiproject.jersey.client.RegistryAwareClientConstants;
-import org.kiwiproject.jersey.client.dropwizard.DropwizardManagedClientBuilder.AddHeadersOnRequestFilter;
+import org.kiwiproject.jersey.client.filter.AddHeadersClientRequestFilter;
 import org.kiwiproject.registry.client.RegistryClient;
 import org.kiwiproject.test.util.Fixtures;
 
@@ -132,7 +132,7 @@ class DropwizardManagedClientBuilderTest {
                     .buildManagedJerseyClient();
 
             assertThat(client).isInstanceOf(Client.class);
-            assertThat(isFeatureRegisteredByClass(client, AddHeadersOnRequestFilter.class)).isFalse();
+            assertThat(isFeatureRegisteredByClass(client, AddHeadersClientRequestFilter.class)).isFalse();
         }
 
         @Test
@@ -230,7 +230,7 @@ class DropwizardManagedClientBuilderTest {
                             ))
                     .buildManagedJerseyClient();
 
-            assertThat(isFeatureRegisteredByClass(client, AddHeadersOnRequestFilter.class)).isTrue();
+            assertThat(isFeatureRegisteredByClass(client, AddHeadersClientRequestFilter.class)).isTrue();
 
             var entity = makeEchoHeadersRequest(client);
             assertThat(entity).contains(
@@ -331,7 +331,7 @@ class DropwizardManagedClientBuilderTest {
                     .buildManagedRegistryAwareClient();
 
             assertThat(client).isInstanceOf(RegistryAwareClient.class);
-            assertThat(isFeatureRegisteredByClass(client, AddHeadersOnRequestFilter.class)).isFalse();
+            assertThat(isFeatureRegisteredByClass(client, AddHeadersClientRequestFilter.class)).isFalse();
         }
 
         @Test
@@ -346,7 +346,7 @@ class DropwizardManagedClientBuilderTest {
                     ))
                     .buildManagedRegistryAwareClient();
 
-            assertThat(isFeatureRegisteredByClass(client, AddHeadersOnRequestFilter.class)).isTrue();
+            assertThat(isFeatureRegisteredByClass(client, AddHeadersClientRequestFilter.class)).isTrue();
 
             var entity = makeEchoHeadersRequest(client);
             assertThat(entity).contains(


### PR DESCRIPTION
* Move AddHeadersOnRequestFilter in DropwizardManagedClientBuilder
  to a top-level class in a new 'jersey' subpackage, and rename it to
  AddHeadersClientRequestFilte