### PR TITLE
Reduce log level in AddHeadersClientRequestFilter

### DIFF
--- a/src/main/java/org/kiwiproject/jersey/client/filter/AddHeadersClientRequestFilter.java
+++ b/src/main/java/org/kiwiproject/jersey/client/filter/AddHeadersClientRequestFilter.java
@@ -90,7 +90,7 @@ public class AddHeadersClientRequestFilter implements ClientRequestFilter {
         } else if (nonNull(headersSupplier)) {
             client.register(AddHeadersClientRequestFilter.fromMapSupplier(headersSupplier));
         } else {
-            LOG.warn("Not registering AddHeadersClientRequestFilter: headersSupplier and headersMultivalueSupplier are both null");
+            LOG.debug("Not registering AddHeadersClientRequestFilter: headersSupplier and headersMultivalueSupplier are both null");
         }
     }
 


### PR DESCRIPTION
In createAndRegister, if the headersSupplier and headersMultivalueSupplier are both null,
there is no need to log at WARN level. The method is esigned to let you call it with one or
both arguments having null values. So, reduce the level down to DEBUG so that it's not
generally seen.