### PR TITLE
Add ResetLogbackLoggingExtension to client tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- TODO: Remove once update to kiwi-test 3.12.0+ (currently required by ResetLogbackLoggingExtension) -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientTest.java
@@ -41,6 +41,7 @@ import org.kiwiproject.registry.model.Port.PortType;
 import org.kiwiproject.registry.model.Port.Security;
 import org.kiwiproject.registry.model.ServiceInstance;
 import org.kiwiproject.registry.model.ServicePaths;
+import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
 
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,7 @@ import java.util.random.RandomGenerator;
 import java.util.stream.IntStream;
 
 @DisplayName("RegistryAwareClient")
+@ExtendWith(ResetLogbackLoggingExtension.class)
 @ExtendWith(DropwizardExtensionsSupport.class)
 class RegistryAwareClientTest {
 

--- a/src/test/java/org/kiwiproject/jersey/client/dropwizard/DropwizardClientsTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/dropwizard/DropwizardClientsTest.java
@@ -34,6 +34,7 @@ import org.kiwiproject.jersey.client.RegistryAwareClient;
 import org.kiwiproject.json.JsonHelper;
 import org.kiwiproject.registry.NoOpRegistryClient;
 import org.kiwiproject.registry.client.RegistryClient;
+import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -41,6 +42,7 @@ import java.time.ZonedDateTime;
 import java.util.concurrent.ThreadLocalRandom;
 
 @DisplayName("DropwizardClients")
+@ExtendWith(ResetLogbackLoggingExtension.class)
 @ExtendWith(DropwizardExtensionsSupport.class)
 class DropwizardClientsTest {
 

--- a/src/test/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilderTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/dropwizard/DropwizardManagedClientBuilderTest.java
@@ -43,6 +43,7 @@ import org.kiwiproject.jersey.client.RegistryAwareClient;
 import org.kiwiproject.jersey.client.RegistryAwareClientConstants;
 import org.kiwiproject.jersey.client.filter.AddHeadersClientRequestFilter;
 import org.kiwiproject.registry.client.RegistryClient;
+import org.kiwiproject.test.junit.jupiter.ResetLogbackLoggingExtension;
 import org.kiwiproject.test.util.Fixtures;
 
 import java.io.File;
@@ -50,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 
 @DisplayName("DropwizardManagedClientBuilder")
+@ExtendWith(ResetLogbackLoggingExtension.class)
 @ExtendWith(DropwizardExtensionsSupport.class)
 class DropwizardManagedClientBuilderTest {
 


### PR DESCRIPTION
Use ResetLogbackLoggingExtension so that the Logback configuration is reset after tests that use DropwizardClientExtension.