### PR TITLE
feat: add keyStore and trustStore methods to ClientBuilder

### DIFF
--- a/src/main/java/org/kiwiproject/jersey/client/ClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/ClientBuilder.java
@@ -7,6 +7,7 @@ import org.kiwiproject.registry.client.RegistryClient;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import java.security.KeyStore;
 import java.time.Duration;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -104,6 +105,53 @@ public interface ClientBuilder {
      * @return this builder
      */
     ClientBuilder sslContext(SSLContext sslContext);
+
+    /**
+     * Sets the client-side key store. Key store contains client's private keys and
+     * the certificates with their corresponding public keys.
+     * <p>
+     * <strong>Note:</strong> Setting a key store resets any SSL context previously
+     * set via {@link #sslContext(SSLContext)}.
+     * <p>
+     * Use this only if you need to enable 2-way SSL (client certificate authentication).
+     *
+     * @param keyStore the client-side key store; must not be null
+     * @param password the key store password as a char array
+     * @return this builder
+     * @see jakarta.ws.rs.client.ClientBuilder#keyStore(KeyStore, char[])
+     */
+    ClientBuilder keyStore(KeyStore keyStore, char[] password);
+
+    /**
+     * Sets the client-side key store. Key store contains client's private keys and
+     * the certificates with their corresponding public keys.
+     * <p>
+     * <strong>Note:</strong> Setting a key store resets any SSL context previously
+     * set via {@link #sslContext(SSLContext)}. For improved security, prefer
+     * {@link #keyStore(KeyStore, char[])} to avoid storing passwords in String objects.
+     * <p>
+     * Use this only if you need to enable 2-way SSL (client certificate authentication).
+     *
+     * @param keyStore the client-side key store; must not be null
+     * @param password the key store password as a String
+     * @return this builder
+     * @see jakarta.ws.rs.client.ClientBuilder#keyStore(KeyStore, String)
+     */
+    ClientBuilder keyStore(KeyStore keyStore, String password);
+
+    /**
+     * Sets the client-side trust store. The trust store is expected to contain
+     * certificates from parties the client expects to communicate with, or from
+     * Certificate Authorities trusted to identify those parties.
+     * <p>
+     * <strong>Note:</strong> Setting a trust store resets any SSL context previously
+     * set via {@link #sslContext(SSLContext)}.
+     *
+     * @param trustStore the client-side trust store; must not be null
+     * @return this builder
+     * @see jakarta.ws.rs.client.ClientBuilder#trustStore(KeyStore)
+     */
+    ClientBuilder trustStore(KeyStore trustStore);
 
     /**
      * Provides a {@link TlsConfigProvider} to use to provide TLS configuration.

--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
@@ -15,6 +15,7 @@ import org.kiwiproject.registry.client.RegistryClient;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import java.security.KeyStore;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
@@ -95,6 +96,27 @@ public class RegistryAwareClientBuilder implements ClientBuilder {
 
         sslContextWasSetOnThis = true;
 
+        return this;
+    }
+
+    @Override
+    public ClientBuilder keyStore(KeyStore keyStore, char[] password) {
+        jerseyClientBuilder.keyStore(keyStore, password);
+        sslContextWasSetOnThis = false;
+        return this;
+    }
+
+    @Override
+    public ClientBuilder keyStore(KeyStore keyStore, String password) {
+        jerseyClientBuilder.keyStore(keyStore, password);
+        sslContextWasSetOnThis = false;
+        return this;
+    }
+
+    @Override
+    public ClientBuilder trustStore(KeyStore trustStore) {
+        jerseyClientBuilder.trustStore(trustStore);
+        sslContextWasSetOnThis = false;
         return this;
     }
 

--- a/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
+++ b/src/main/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilder.java
@@ -33,6 +33,7 @@ public class RegistryAwareClientBuilder implements ClientBuilder {
     private final JerseyClientBuilder jerseyClientBuilder = new JerseyClientBuilder();
 
     private boolean sslContextWasSetOnThis;
+    private boolean keyOrTrustStoreWasSetOnThis;
     private boolean hostnameVerifierWasSetOnThis;
     private RegistryClient registryClient;
     private Supplier<Map<String, Object>> headersSupplier;
@@ -102,21 +103,21 @@ public class RegistryAwareClientBuilder implements ClientBuilder {
     @Override
     public ClientBuilder keyStore(KeyStore keyStore, char[] password) {
         jerseyClientBuilder.keyStore(keyStore, password);
-        sslContextWasSetOnThis = false;
+        keyOrTrustStoreWasSetOnThis = true;
         return this;
     }
 
     @Override
     public ClientBuilder keyStore(KeyStore keyStore, String password) {
         jerseyClientBuilder.keyStore(keyStore, password);
-        sslContextWasSetOnThis = false;
+        keyOrTrustStoreWasSetOnThis = true;
         return this;
     }
 
     @Override
     public ClientBuilder trustStore(KeyStore trustStore) {
         jerseyClientBuilder.trustStore(trustStore);
-        sslContextWasSetOnThis = false;
+        keyOrTrustStoreWasSetOnThis = true;
         return this;
     }
 
@@ -186,7 +187,7 @@ public class RegistryAwareClientBuilder implements ClientBuilder {
         setReadTimeoutIfNotConfigured(configPropertyNames);
         setNoopHostNameVerifierIfNotSet();
 
-        if (!sslContextWasSetOnThis) {
+        if (!sslContextWasSetOnThis && !keyOrTrustStoreWasSetOnThis) {
             LOG.info(DEFAULT_TLS_INFO_MESSAGE);
         }
 

--- a/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
+++ b/src/test/java/org/kiwiproject/jersey/client/RegistryAwareClientBuilderTest.java
@@ -36,6 +36,8 @@ import org.kiwiproject.test.util.Fixtures;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
+import java.io.FileInputStream;
+import java.security.KeyStore;
 import java.util.List;
 import java.util.Map;
 
@@ -225,8 +227,119 @@ class RegistryAwareClientBuilderTest {
                 .isNotNull();
     }
 
-    private static String getUnitTestKeyStorePath() {
-        return Fixtures.fixturePath("RegistryAwareClientBuilderTest/unitteststore.jks").toAbsolutePath().toString();
+    @Test
+    void shouldAcceptKeyStoreWithCharArrayPassword() throws Exception {
+        var keyStore = loadUnitTestKeyStore();
+
+        client = builder.registryClient(registryClient).keyStore(keyStore, "password".toCharArray()).build();
+
+        assertThat(client.getSslContext()).isNotNull();
+    }
+
+    @Test
+    void shouldAcceptKeyStoreWithStringPassword() throws Exception {
+        var keyStore = loadUnitTestKeyStore();
+
+        client = builder.registryClient(registryClient).keyStore(keyStore, "password").build();
+
+        assertThat(client.getSslContext()).isNotNull();
+    }
+
+    @Test
+    void shouldAcceptTrustStore() throws Exception {
+        var trustStore = loadUnitTestKeyStore();
+
+        client = builder.registryClient(registryClient).trustStore(trustStore).build();
+
+        assertThat(client.getSslContext()).isNotNull();
+    }
+
+    @Test
+    void shouldNotRetainSslContextWhenKeyStoreIsSetAfterSslContext() throws Exception {
+        var path = getUnitTestKeyStorePath();
+        var sslContext = TlsContextConfiguration.builder()
+                .trustStorePath(path)
+                .trustStorePassword("password")
+                .build()
+                .toSSLContext();
+
+        var keyStore = loadUnitTestKeyStore();
+
+        client = builder
+                .registryClient(registryClient)
+                .sslContext(sslContext)
+                .keyStore(keyStore, "password".toCharArray())
+                .build();
+
+        assertThat(client.getSslContext()).isNotSameAs(sslContext);
+    }
+
+    @Test
+    void shouldNotRetainSslContextWhenTrustStoreIsSetAfterSslContext() throws Exception {
+        var path = getUnitTestKeyStorePath();
+        var sslContext = TlsContextConfiguration.builder()
+                .trustStorePath(path)
+                .trustStorePassword("password")
+                .build()
+                .toSSLContext();
+
+        var trustStore = loadUnitTestKeyStore();
+
+        client = builder
+                .registryClient(registryClient)
+                .sslContext(sslContext)
+                .trustStore(trustStore)
+                .build();
+
+        assertThat(client.getSslContext()).isNotSameAs(sslContext);
+    }
+
+    @Test
+    void shouldUseSslContextWhenSetAfterKeyStore() throws Exception {
+        var path = getUnitTestKeyStorePath();
+        var sslContext = TlsContextConfiguration.builder()
+                .trustStorePath(path)
+                .trustStorePassword("password")
+                .build()
+                .toSSLContext();
+
+        var keyStore = loadUnitTestKeyStore();
+
+        client = builder
+                .registryClient(registryClient)
+                .keyStore(keyStore, "password".toCharArray())
+                .sslContext(sslContext)
+                .build();
+
+        assertThat(client.getSslContext()).isSameAs(sslContext);
+    }
+
+    @Test
+    void shouldUseSslContextWhenSetAfterTrustStore() throws Exception {
+        var path = getUnitTestKeyStorePath();
+        var sslContext = TlsContextConfiguration.builder()
+                .trustStorePath(path)
+                .trustStorePassword("password")
+                .build()
+                .toSSLContext();
+
+        var trustStore = loadUnitTestKeyStore();
+
+        client = builder
+                .registryClient(registryClient)
+                .trustStore(trustStore)
+                .sslContext(sslContext)
+                .build();
+
+        assertThat(client.getSslContext()).isSameAs(sslContext);
+    }
+
+    private static KeyStore loadUnitTestKeyStore() throws Exception {
+        var keyStore = KeyStore.getInstance("JKS");
+        try (var is = new FileInputStream(getUnitTestKeyStorePath())) {
+            keyStore.load(is, "password".toCharArray());
+        }
+        return keyStore;
     }
 
     @Test
@@ -304,6 +417,10 @@ class RegistryAwareClientBuilderTest {
 
         assertThat(client.getSslContext()).isSameAs(sslContext);
         assertThat(client.getHostnameVerifier()).isSameAs(verifier);
+    }
+
+    private static String getUnitTestKeyStorePath() {
+        return Fixtures.fixturePath("RegistryAwareClientBuilderTest/unitteststore.jks").toAbsolutePath().toString();
     }
 
     @Test


### PR DESCRIPTION
Mirror the corresponding methods in jakarta.ws.rs.client.ClientBuilder.
Adds keyStore(KeyStore, char[]), keyStore(KeyStore, String), and
trustStore(KeyStore) to the ClientBuilder interface and implements
them in RegistryAwareClientBuilder, each delegating to the underlying
JerseyClientBuilder and resetting sslContextWasSetOnThis to false
to reflect that Jersey clears any previously set SSLContext when a
key store or trust store is configured.

Closes #450