### PR TITLE
Bump kiwi dependency versions in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <dropwizard-config-providers.version>3.0.2</dropwizard-config-providers.version>
-        <kiwi.version>5.3.1</kiwi.version>
-        <kiwi-bom.version>3.2.0</kiwi-bom.version>
-        <service-discovery-client.version>3.0.2</service-discovery-client.version>
+        <dropwizard-config-providers.version>3.0.3</dropwizard-config-providers.version>
+        <kiwi.version>5.4.0</kiwi.version>
+        <kiwi-bom.version>3.3.0</kiwi-bom.version>
+        <service-discovery-client.version>3.1.0</service-discovery-client.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>4.1.0</kiwi-test.version>
+        <kiwi-test.version>4.2.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_registry-aware-jersey-client</sonar.projectKey>


### PR DESCRIPTION
- Update dropwizard-config-providers to 3.0.3.
- Update kiwi to 5.4.0.
- Update kiwi-bom to 3.3.0.
- Update service-discovery-client to 3.1.0.
- Update kiwi-test to 4.2.0.